### PR TITLE
Add parameter for configuring listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ airthings-exporter --client-id [client_id] --client-secret [client_secret] --dev
 curl -s localhost:8000
 ```
 
+Use the `--port` option have the exporter listen on a different port. Default port is 8000.
+
 ## Tested Devices
 
 - Airthings View Plus

--- a/src/airthings/main.py
+++ b/src/airthings/main.py
@@ -9,14 +9,15 @@ parser = argparse.ArgumentParser(
 parser.add_argument('--client-id')
 parser.add_argument('--client-secret')
 parser.add_argument('--device-id', action='append')
+parser.add_argument('--port', type=int, default=8000, help='Port to listen on (default: 8000)')
 args = parser.parse_args()
 
 REGISTRY.register(CloudCollector(args.client_id, args.client_secret, args.device_id))
 
 
 def main():
-    start_http_server(8000)
-    print('Now listening on port 8000')
+    start_http_server(args.port)
+    print(f'Now listening on port {args.port}')
     while True:
         time.sleep(60)
 


### PR DESCRIPTION
Adds an optional parameter for configuring the listen port, in case 8000 is already in use (as it was on my setup).